### PR TITLE
Don't follow to other domains

### DIFF
--- a/data/target_sites.json
+++ b/data/target_sites.json
@@ -85533,24 +85533,6 @@
     "use_headless_browser": false,
     "works": true
   },
-  "Boing Boin": {
-    "site": "Boing Boin",
-    "article_pause_secs": 0,
-    "domains": [
-      ""
-    ],
-    "feeder_pages": [
-      "https://boingboing.net/"
-    ],
-    "notes": "",
-    "parser_name": "browser_article_based",
-    "parser_params": {},
-    "skip": false,
-    "suffix": "",
-    "use_archive": false,
-    "use_headless_browser": false,
-    "works": true
-  },
   "Watertown Daily Times Online": {
     "site": "Watertown Daily Times Online",
     "article_pause_secs": 0,
@@ -137641,26 +137623,8 @@
     "use_headless_browser": false,
     "works": true
   },
-  "Geeks of Doom": {
-    "site": "Geeks of Doom",
-    "article_pause_secs": 0,
-    "domains": [
-      ""
-    ],
-    "feeder_pages": [
-      "https://www.facebook.com/geeksofdoom/"
-    ],
-    "notes": "",
-    "parser_name": "article_based",
-    "parser_params": {},
-    "skip": false,
-    "suffix": "",
-    "use_archive": false,
-    "use_headless_browser": false,
-    "works": false
-  },
-  "China Law Blo": {
-    "site": "China Law Blo",
+  "China Law Blog": {
+    "site": "China Law Blog",
     "article_pause_secs": 0,
     "domains": [
       ""
@@ -137702,7 +137666,7 @@
       ""
     ],
     "feeder_pages": [
-      "https://www.loc.gov/item/lcwaN0000345/"
+      "https://opensecrets.org"
     ],
     "notes": "",
     "parser_name": "browser_article_based",
@@ -139593,8 +139557,8 @@
     "use_headless_browser": false,
     "works": true
   },
-  "Geeks of Doo": {
-    "site": "Geeks of Doo",
+  "Geeks of Doom": {
+    "site": "Geeks of Doom",
     "article_pause_secs": 0,
     "domains": [
       ""

--- a/data/target_sites.json
+++ b/data/target_sites.json
@@ -139429,14 +139429,14 @@
     "use_headless_browser": false,
     "works": true
   },
-  "AmmoLand.co": {
+  "AmmoLand.com": {
     "site": "AmmoLand.co",
     "article_pause_secs": 0,
     "domains": [
-      "ammoland.co"
+      "ammoland.com"
     ],
     "feeder_pages": [
-      "https://ammoland.co"
+      "https://ammoland.com"
     ],
     "notes": "",
     "parser_name": "article_based",

--- a/js/tools/sites-editor/app.js
+++ b/js/tools/sites-editor/app.js
@@ -4,26 +4,39 @@ var renderSites = require('./dom/render-sites');
 var renderDownloadLink = require('render-dl-link');
 var noThrowJSONParse = require('no-throw-json-parse');
 var fieldsThatShouldRenderAsJSON = require('./json-fields');
+var { getSitesFromDOM } = require('./utils');
 
 (function go() {
   window.onerror = reportTopLevelError;
   wireControls({
     onLoadSites({ sites }) {
-      renderSites({ siteData: Object.values(sites) });
+      renderSites({
+        siteData: Object.values(sites),
+        onValueChange: saveLocally,
+      });
     },
     onSaveSites,
   });
+
+  if (localStorage.sites) {
+    renderSites({
+      siteData: Object.values(JSON.parse(localStorage.sites)),
+      onValueChange: saveLocally,
+    });
+  }
 })();
 
 function reportTopLevelError(msg, url, lineNo, columnNo, error) {
   handleError(error);
 }
 
-function onSaveSites({ sites }) {
-  sites.forEach(convertJSONFieldsToObjects);
-  // If we ever have date fields, convert them here.
-  // sites.forEach(convertDateFieldsToDates);
-  var sitesDict = arrangeSitesIntoDict(sites);
+function saveLocally() {
+  var sitesDict = sitesToDict(getSitesFromDOM());
+  localStorage.sites = JSON.stringify(sitesDict);
+}
+
+function onSaveSites() {
+  var sitesDict = JSON.parse(localStorage.sites);
   renderDownloadLink({
     blob: new Blob([JSON.stringify(sitesDict, null, 2)], {
       type: 'application/json',
@@ -32,6 +45,13 @@ function onSaveSites({ sites }) {
     downloadLinkText: 'Download the sites file',
     filename: 'target_sites.json',
   });
+}
+
+function sitesToDict(sites) {
+  sites.forEach(convertJSONFieldsToObjects);
+  // If we ever have date fields, convert them here.
+  // sites.forEach(convertDateFieldsToDates);
+  return arrangeSitesIntoDict(sites);
 }
 
 function arrangeSitesIntoDict(sites) {

--- a/js/tools/sites-editor/dom/render-sites.js
+++ b/js/tools/sites-editor/dom/render-sites.js
@@ -15,7 +15,7 @@ var selectFields = ['environment', 'form', 'purpose', 'releaseState'];
 var numFields = ['article_pause_secs'];
 var fixedValuesForFields = {};
 
-function renderSites({ siteData }) {
+function renderSites({ siteData, onValueChange }) {
   normalizeObjects(siteData);
   var sites = siteRoot.selectAll('.site').data(siteData, accessor('site'));
   sites.exit().remove();
@@ -37,13 +37,13 @@ function renderSites({ siteData }) {
     .text((x) => x);
 
   var newSites = sites.enter().append('tr').classed('site', true);
-  appendElementsForSites(newSites, siteData[0]);
+  appendElementsForSites(newSites, siteData[0], onValueChange);
 
   var sitesToUpdate = newSites.merge(sites);
   fields.forEach(curry(updateSitesField)(sitesToUpdate));
 }
 
-function appendElementsForSites(sitesSel, exampleSite) {
+function appendElementsForSites(sitesSel, exampleSite, onValueChange) {
   // Move 'site' to the front.
   var fields = Object.keys(exampleSite);
   fields.splice(fields.indexOf('site'), 1);
@@ -54,11 +54,16 @@ function appendElementsForSites(sitesSel, exampleSite) {
   function appendElementsForField(field) {
     let container = sitesSel.append('td').classed('field-container', true);
     // container.append('div').classed('field-label', true).text(field);
-    appendControlForValue(container, field, typeof exampleSite[field]);
+    appendControlForValue(
+      container,
+      field,
+      typeof exampleSite[field],
+      onValueChange
+    );
   }
 }
 
-function appendControlForValue(container, field, valueType) {
+function appendControlForValue(container, field, valueType, onValueChange) {
   if (jsonFieldNames.includes(field)) {
     container.append('textarea').attr('data-of', field);
   } else if (selectFields.includes(field)) {
@@ -73,6 +78,7 @@ function appendControlForValue(container, field, valueType) {
     //   .merge(options)
     //   .text(accessor('identity'))
     //   .attr('value', accessor('identity'));
+    selectControl.on('change', onValueChange);
   } else {
     let input = container.append('input').attr('data-of', field);
     if (valueType === 'boolean') {
@@ -84,6 +90,7 @@ function appendControlForValue(container, field, valueType) {
     } else {
       input.attr('type', 'text');
     }
+    input.on('change', onValueChange);
   }
 }
 

--- a/js/tools/sites-editor/dom/wire-controls.js
+++ b/js/tools/sites-editor/dom/wire-controls.js
@@ -1,8 +1,5 @@
 var d3 = require('d3-selection');
-var of = require('object-form');
-
 var listenersInit = false;
-var objectFromDOM = of.ObjectFromDOM({});
 
 function wireControls({ onLoadSites, onSaveSites }) {
   if (listenersInit) {
@@ -45,12 +42,7 @@ function wireControls({ onLoadSites, onSaveSites }) {
   }
 
   function onSave() {
-    var sites = [];
-    var siteItems = document.querySelectorAll('#site-root .site');
-    for (var i = 0; i < siteItems.length; ++i) {
-      sites.push(objectFromDOM(siteItems[i]));
-    }
-    onSaveSites({ sites });
+    onSaveSites();
   }
 }
 

--- a/js/tools/sites-editor/index.js
+++ b/js/tools/sites-editor/index.js
@@ -5,26 +5,39 @@ var renderSites = require('./dom/render-sites');
 var renderDownloadLink = require('render-dl-link');
 var noThrowJSONParse = require('no-throw-json-parse');
 var fieldsThatShouldRenderAsJSON = require('./json-fields');
+var { getSitesFromDOM } = require('./utils');
 
 (function go() {
   window.onerror = reportTopLevelError;
   wireControls({
     onLoadSites({ sites }) {
-      renderSites({ siteData: Object.values(sites) });
+      renderSites({
+        siteData: Object.values(sites),
+        onValueChange: saveLocally,
+      });
     },
     onSaveSites,
   });
+
+  if (localStorage.sites) {
+    renderSites({
+      siteData: Object.values(JSON.parse(localStorage.sites)),
+      onValueChange: saveLocally,
+    });
+  }
 })();
 
 function reportTopLevelError(msg, url, lineNo, columnNo, error) {
   handleError(error);
 }
 
-function onSaveSites({ sites }) {
-  sites.forEach(convertJSONFieldsToObjects);
-  // If we ever have date fields, convert them here.
-  // sites.forEach(convertDateFieldsToDates);
-  var sitesDict = arrangeSitesIntoDict(sites);
+function saveLocally() {
+  var sitesDict = sitesToDict(getSitesFromDOM());
+  localStorage.sites = JSON.stringify(sitesDict);
+}
+
+function onSaveSites() {
+  var sitesDict = JSON.parse(localStorage.sites);
   renderDownloadLink({
     blob: new Blob([JSON.stringify(sitesDict, null, 2)], {
       type: 'application/json',
@@ -33,6 +46,13 @@ function onSaveSites({ sites }) {
     downloadLinkText: 'Download the sites file',
     filename: 'target_sites.json',
   });
+}
+
+function sitesToDict(sites) {
+  sites.forEach(convertJSONFieldsToObjects);
+  // If we ever have date fields, convert them here.
+  // sites.forEach(convertDateFieldsToDates);
+  return arrangeSitesIntoDict(sites);
 }
 
 function arrangeSitesIntoDict(sites) {
@@ -73,7 +93,7 @@ function convertJSONFieldsToObjects(site) {
 // }
 // }
 
-},{"./dom/render-sites":2,"./dom/wire-controls":3,"./json-fields":4,"handle-error-web":7,"no-throw-json-parse":9,"render-dl-link":12}],2:[function(require,module,exports){
+},{"./dom/render-sites":2,"./dom/wire-controls":3,"./json-fields":4,"./utils":13,"handle-error-web":7,"no-throw-json-parse":9,"render-dl-link":12}],2:[function(require,module,exports){
 var d3 = require('d3-selection');
 var siteRoot = d3.select('#site-root');
 var accessor = require('accessor')();
@@ -91,7 +111,7 @@ var selectFields = ['environment', 'form', 'purpose', 'releaseState'];
 var numFields = ['article_pause_secs'];
 var fixedValuesForFields = {};
 
-function renderSites({ siteData }) {
+function renderSites({ siteData, onValueChange }) {
   normalizeObjects(siteData);
   var sites = siteRoot.selectAll('.site').data(siteData, accessor('site'));
   sites.exit().remove();
@@ -113,13 +133,13 @@ function renderSites({ siteData }) {
     .text((x) => x);
 
   var newSites = sites.enter().append('tr').classed('site', true);
-  appendElementsForSites(newSites, siteData[0]);
+  appendElementsForSites(newSites, siteData[0], onValueChange);
 
   var sitesToUpdate = newSites.merge(sites);
   fields.forEach(curry(updateSitesField)(sitesToUpdate));
 }
 
-function appendElementsForSites(sitesSel, exampleSite) {
+function appendElementsForSites(sitesSel, exampleSite, onValueChange) {
   // Move 'site' to the front.
   var fields = Object.keys(exampleSite);
   fields.splice(fields.indexOf('site'), 1);
@@ -130,11 +150,16 @@ function appendElementsForSites(sitesSel, exampleSite) {
   function appendElementsForField(field) {
     let container = sitesSel.append('td').classed('field-container', true);
     // container.append('div').classed('field-label', true).text(field);
-    appendControlForValue(container, field, typeof exampleSite[field]);
+    appendControlForValue(
+      container,
+      field,
+      typeof exampleSite[field],
+      onValueChange
+    );
   }
 }
 
-function appendControlForValue(container, field, valueType) {
+function appendControlForValue(container, field, valueType, onValueChange) {
   if (jsonFieldNames.includes(field)) {
     container.append('textarea').attr('data-of', field);
   } else if (selectFields.includes(field)) {
@@ -149,6 +174,7 @@ function appendControlForValue(container, field, valueType) {
     //   .merge(options)
     //   .text(accessor('identity'))
     //   .attr('value', accessor('identity'));
+    selectControl.on('change', onValueChange);
   } else {
     let input = container.append('input').attr('data-of', field);
     if (valueType === 'boolean') {
@@ -160,6 +186,7 @@ function appendControlForValue(container, field, valueType) {
     } else {
       input.attr('type', 'text');
     }
+    input.on('change', onValueChange);
   }
 }
 
@@ -216,10 +243,7 @@ module.exports = renderSites;
 
 },{"../json-fields":4,"accessor":5,"d3-selection":6,"lodash.curry":8,"normalize-objects":10}],3:[function(require,module,exports){
 var d3 = require('d3-selection');
-var of = require('object-form');
-
 var listenersInit = false;
-var objectFromDOM = of.ObjectFromDOM({});
 
 function wireControls({ onLoadSites, onSaveSites }) {
   if (listenersInit) {
@@ -262,12 +286,7 @@ function wireControls({ onLoadSites, onSaveSites }) {
   }
 
   function onSave() {
-    var sites = [];
-    var siteItems = document.querySelectorAll('#site-root .site');
-    for (var i = 0; i < siteItems.length; ++i) {
-      sites.push(objectFromDOM(siteItems[i]));
-    }
-    onSaveSites({ sites });
+    onSaveSites();
   }
 }
 
@@ -283,7 +302,7 @@ function getFile() {
 
 module.exports = wireControls;
 
-},{"d3-selection":6,"object-form":11}],4:[function(require,module,exports){
+},{"d3-selection":6}],4:[function(require,module,exports){
 module.exports = [
   { field: 'parser_params', type: 'object' },
   { field: 'domains', type: 'array' },
@@ -2782,4 +2801,19 @@ function renderDownloadLink({
 
 module.exports = renderDownloadLink;
 
-},{}]},{},[1]);
+},{}],13:[function(require,module,exports){
+var of = require('object-form');
+var objectFromDOM = of.ObjectFromDOM({});
+
+function getSitesFromDOM() {
+  var sites = [];
+  var siteItems = document.querySelectorAll('#site-root .site');
+  for (var i = 0; i < siteItems.length; ++i) {
+    sites.push(objectFromDOM(siteItems[i]));
+  }
+  return sites;
+}
+
+module.exports = { getSitesFromDOM };
+
+},{"object-form":11}]},{},[1]);

--- a/js/tools/sites-editor/utils.js
+++ b/js/tools/sites-editor/utils.js
@@ -1,0 +1,13 @@
+var of = require('object-form');
+var objectFromDOM = of.ObjectFromDOM({});
+
+function getSitesFromDOM() {
+  var sites = [];
+  var siteItems = document.querySelectorAll('#site-root .site');
+  for (var i = 0; i < siteItems.length; ++i) {
+    sites.push(objectFromDOM(siteItems[i]));
+  }
+  return sites;
+}
+
+module.exports = { getSitesFromDOM };

--- a/parsers/utils.py
+++ b/parsers/utils.py
@@ -108,7 +108,7 @@ def grab_url(url, max_depth=5):
         logging.info("http error retry")
         logging.info(e.reason)
         if e.reason == "Redirect to a different domain.":
-            return ""
+            raise e
         else:
             retry = True
         

--- a/parsers/utils.py
+++ b/parsers/utils.py
@@ -4,8 +4,28 @@ import socket
 from bs4 import BeautifulSoup
 import http.cookiejar as cookielib
 import urllib
+from urllib.parse import urlparse
 import time
 import logging
+
+class AvoidNewDomainRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        domain_parts = urlparse(req.full_url).netloc.split(".")
+        new_domain_parts = urlparse(newurl).netloc.split(".")
+        
+        if domain_parts[-2:] != new_domain_parts[-2:]:
+            print(f"Not follwing redirect from {req.full_url} to {newurl}")
+            raise urllib.error.HTTPError(
+                    req.full_url, 302, "Redirect to a different domain.",
+                    headers, fp)
+        else:
+            return urllib.request.Request(newurl, None, headers);
+
+cj = cookielib.CookieJar()
+opener = urllib.request.build_opener(
+        AvoidNewDomainRedirectHandler, urllib.request.HTTPCookieProcessor(cj)
+        )
+urllib.request.install_opener(opener)
 
 def get_meta_content_by_attr(bs_meta_list, attr, val, default=None):
     # print("name: {}".format(bs_meta_list.name))
@@ -70,15 +90,13 @@ def make_url_safe(url):
     parsed = urllib.parse.urlparse(url)
     return parsed._replace(path=parsed.path.replace(" ", "%20")).geturl()
 
-def grab_url(url, max_depth=5, opener=None):
-    if opener is None:
-        cj = cookielib.CookieJar()
-        opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+def grab_url(url, max_depth=5):
     retry = False
     url = make_url_safe(url) 
     logging.info("grabbing " + url)
     try:
-        text = opener.open(url, timeout=30).read()
+        text = urllib.request.urlopen(url, timeout=30).read()
+
         if b"<title>NY Times Advertisement</title>" in text:
             logging.info("advert retry")
             retry = True
@@ -89,7 +107,11 @@ def grab_url(url, max_depth=5, opener=None):
         logging.info(url)
         logging.info("http error retry")
         logging.info(e.reason)
-        retry = True
+        if e.reason == "Redirect to a different domain.":
+            return ""
+        else:
+            retry = True
+        
     except Exception as e:
         logging.info(f"Error {e} while opening {url}.")
         return ""
@@ -102,7 +124,7 @@ def grab_url(url, max_depth=5, opener=None):
         #        if max_depth == 0:
         #            raise Exception('Too many attempts to download %s' % url)
         time.sleep(5.0)
-        return grab_url(url, max_depth - 1, opener)
+        return grab_url(url, max_depth - 1)
     return text
 
 

--- a/simple_scrape.py
+++ b/simple_scrape.py
@@ -72,6 +72,17 @@ if not site:
 
 # Assuming we're running from the project root.
 
+def report_disallowed_redirect(site_name, parser_name, e):
+    logging.info(f"Disallowed redirect: {e.reason}")
+    res = dynamo.put_item(
+        TableName="nyt-said-site-results",
+        Item={
+            "site": {"S": site_name},
+            "articles_processed": {"N": str(articles_processed)},
+            "succeeding_parser_name": {"S": parser_name},
+            "site_is_invalid": {"BOOL": True}
+        })
+
 def humanize_url(article):
     return article.split("/")[-1].split(".html")[0].replace("-", " ")
 
@@ -234,6 +245,10 @@ def process_with_request(link, site, parser_name, parser_params):
         if e.code == 404:
             self.real_article = False
             return 
+        if e.code == 302:
+            report_disallowed_redirect(site["site"], parser_name, e)
+            return
+
         raise
     print("got html")
 
@@ -286,7 +301,13 @@ def run_brush(parser_name, parser_params):
     else:
         domain = site["feeder_pages"][0].replace("https://", "")
 
-    links = get_feed_urls(site["feeder_pages"], domain, feed_requester)
+    try:
+        links = get_feed_urls(site["feeder_pages"], domain, feed_requester)
+    except urllib2.HTTPError as e:
+        if e.code == 302:
+            report_disallowed_redirect(site["site"], parser_name, e)
+            return
+
     if len(links) < 1:
         add_summary_line("Could not get any top-level links with " + parser_name + ".")
         # If the site has been able to get results before, assume this is a

--- a/test/test_parsers_unit.py
+++ b/test/test_parsers_unit.py
@@ -2,6 +2,7 @@ import unittest
 from parsers.parse_fns import custom_parent, article_based
 from parsers.utils import grab_url
 import os
+import urllib
 
 class ParsersSuite(unittest.TestCase):
     def test_farmersjournal(self):
@@ -26,3 +27,8 @@ class ParsersSuite(unittest.TestCase):
             #     out.close()
             self.assertEqual(parsed["body"], expected_contents)
             f.close()
+
+    def test_redirect(self):
+        self.assertEqual(grab_url("https://naij.com"), "", "Returns nothing because the url redirects to a different domain.")
+        redirect_content = grab_url("https://www.geeksofdoom.com/2026/03/18/spring-2026-book-recommendations-gifts")
+        self.assertTrue(len(redirect_content) > 100, "Returns text because the url redirects but not to a different domain.")

--- a/test/test_parsers_unit.py
+++ b/test/test_parsers_unit.py
@@ -29,6 +29,9 @@ class ParsersSuite(unittest.TestCase):
             f.close()
 
     def test_redirect(self):
-        self.assertEqual(grab_url("https://naij.com"), "", "Returns nothing because the url redirects to a different domain.")
+        with self.assertRaises(urllib.error.HTTPError):
+            # Raises error because the url redirects to a different domain.
+            grab_url("https://naij.com")
+
         redirect_content = grab_url("https://www.geeksofdoom.com/2026/03/18/spring-2026-book-recommendations-gifts")
         self.assertTrue(len(redirect_content) > 100, "Returns text because the url redirects but not to a different domain.")


### PR DESCRIPTION
We get error reports (in nyt-said-failure-reports) that are a result of a site redirecting to another completely different domain. In most cases, this is because the domain expired, and someone else has bought it. To handle this more expediently, `grab_url` no longer follows redirects that go to a different domain and raises an error. `simple_scrape` catches that error and marks the site invalid in Dynamo so that we can automatically take these sites out of the running. 

There may be a few false positives, but I think this will lead to higher quality text overall. Let me know if you don't agree, though!

There's also a change here to make the web app for editing target_sites.json a little less fragile.